### PR TITLE
Fix <br> tag rendering in README

### DIFF
--- a/src/components/readme.tsx
+++ b/src/components/readme.tsx
@@ -88,7 +88,7 @@ export function Readme({ package: packageName }: ReadmeProps) {
 
         {!isLoading && !error && markdownContent && (
           <div className="markdown-content">
-            <Markdown gfm>{markdownContent}</Markdown>
+            <Markdown gfm>{markdownContent.replace(/<br\s*\/?>/gi, '  \n')}</Markdown>
           </div>
         )}
 

--- a/src/components/readme_logic.test.ts
+++ b/src/components/readme_logic.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+
+test('markdownContent regex correctly replaces <br> tags with two spaces and \\n', () => {
+  const content = 'Line 1<br>Line 2<br />Line 3 <BR> Line 4 <br  /> Line 5'
+  const expected = 'Line 1  \nLine 2  \nLine 3   \n Line 4   \n Line 5'
+  const result = content.replace(/<br\s*\/?>/gi, '  \n')
+  assert.strictEqual(result, expected)
+})


### PR DESCRIPTION
This PR fixes the issue where `<br>` tags in NPM package READMEs were displayed as literal text. By pre-processing the markdown content to replace these tags with standard Markdown line breaks (`  \n`), we ensure they render as intended in the `marked-react` component. A unit test was added to verify the replacement logic.

---
*PR created automatically by Jules for task [12297141021539532665](https://jules.google.com/task/12297141021539532665) started by @amio*